### PR TITLE
feat: add responsive megamenu navigation

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/src/components/MenuButton.astro
+++ b/src/components/MenuButton.astro
@@ -1,0 +1,13 @@
+---
+interface Props {
+  open: boolean;
+}
+const { open } = Astro.props as Props;
+---
+<button id="menu-button" type="button" aria-expanded={open ? 'true' : 'false'} aria-label="Abrir menú" class="p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 lg:hidden">
+  <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+</button>

--- a/src/components/NavMega.astro
+++ b/src/components/NavMega.astro
@@ -1,0 +1,194 @@
+---
+import MenuButton from './MenuButton.astro';
+interface CTA { href: string; label: string; icon?: string }
+interface MenuItem { label: string; columns: any[] }
+interface Props {
+  menu: MenuItem[];
+  cta: CTA;
+}
+const { menu, cta } = Astro.props as Props;
+---
+<nav id="meganav" class="bg-white">
+  <div class="max-w-6xl mx-auto px-4 flex items-center justify-between h-16">
+    <a href="/" class="font-bold text-xl">Logo</a>
+    <MenuButton open={false} />
+    <div class="hidden lg:flex items-center gap-8 ml-8">
+      {menu.map((group, index) => (
+        <div class="relative" data-menu-item={index}>
+          <button class="py-2 px-3 font-medium text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500" aria-expanded="false">
+            {group.label}
+          </button>
+          <div class="panel absolute left-1/2 -translate-x-1/2 mt-2 hidden w-screen max-w-6xl" role="menu">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 p-6 bg-white rounded-2xl shadow-xl ring-1 ring-black/5">
+              {group.columns.map(column => (
+                <div>
+                  <h3 class="text-sm font-semibold text-gray-900 mb-2">{column.title}</h3>
+                  <ul class="space-y-2">
+                    {column.items.map(item => (
+                      <li>
+                        <a href={item.href} class="flex items-start gap-3 p-2 rounded-lg hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" role="menuitem">
+                          <svg class="h-5 w-5 text-gray-500" aria-hidden="true"></svg>
+                          <div>
+                            <p class="font-medium">{item.label}</p>
+                            <p class="text-sm text-gray-600">{item.desc}</p>
+                          </div>
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+      <a href={cta.href} class="ml-4 inline-block bg-blue-600 text-white px-4 py-2 rounded-md font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">{cta.label}</a>
+    </div>
+  </div>
+
+  <div id="mobile-panel" class="fixed inset-0 z-50 bg-white overflow-y-auto transform -translate-x-full transition-transform duration-200 lg:hidden">
+    <div class="p-4 space-y-4">
+      {menu.map((group, index) => (
+        <div class="border-b">
+          <button class="accordion-btn w-full flex justify-between items-center py-4 font-medium text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500" aria-expanded="false">
+            {group.label}
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="accordion-panel hidden pl-4 pb-4 space-y-2">
+            {group.columns.map(col => (
+              <div>
+                <h3 class="text-sm font-semibold text-gray-900 mt-2">{col.title}</h3>
+                <ul class="space-y-2">
+                  {col.items.map(item => (
+                    <li>
+                      <a href={item.href} class="block p-2 rounded-lg hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" role="menuitem">{item.label}</a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+      <a href={cta.href} class="block bg-blue-600 text-white px-4 py-2 rounded-md font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">{cta.label}</a>
+    </div>
+  </div>
+</nav>
+<script client:load>
+  const nav = document.getElementById('meganav');
+  const items = nav.querySelectorAll('[data-menu-item]');
+  let openIndex = -1;
+  let hoverTimeout;
+  function openMenu(i) {
+    if (openIndex === i) return;
+    closeMenu();
+    openIndex = i;
+    const wrap = items[i];
+    const btn = wrap.querySelector('button');
+    const panel = wrap.querySelector('.panel');
+    btn.setAttribute('aria-expanded', 'true');
+    panel.classList.remove('hidden');
+  }
+  function closeMenu() {
+    if (openIndex === -1) return;
+    const wrap = items[openIndex];
+    const btn = wrap.querySelector('button');
+    const panel = wrap.querySelector('.panel');
+    btn.setAttribute('aria-expanded', 'false');
+    panel.classList.add('hidden');
+    openIndex = -1;
+  }
+  items.forEach((wrap, idx) => {
+    const btn = wrap.querySelector('button');
+    const panel = wrap.querySelector('.panel');
+    btn.addEventListener('mouseenter', () => {
+      hoverTimeout = setTimeout(() => openMenu(idx), 150);
+    });
+    btn.addEventListener('mouseleave', () => clearTimeout(hoverTimeout));
+    wrap.addEventListener('mouseleave', () => closeMenu());
+    btn.addEventListener('click', () => {
+      if (openIndex === idx) closeMenu(); else openMenu(idx);
+    });
+    btn.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') { closeMenu(); btn.focus(); }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (openIndex === idx) closeMenu(); else openMenu(idx);
+      }
+      if (e.key === 'ArrowDown') {
+        openMenu(idx);
+        const first = panel.querySelector('[role="menuitem"]');
+        first && first.focus();
+      }
+    });
+  });
+  document.addEventListener('click', (e) => {
+    if (!nav.contains(e.target)) closeMenu();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeMenu();
+  });
+  nav.querySelectorAll('[role="menu"]').forEach(menu => {
+    const mItems = menu.querySelectorAll('[role="menuitem"]');
+    mItems.forEach((item, i) => {
+      item.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          mItems[(i + 1) % mItems.length].focus();
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          mItems[(i - 1 + mItems.length) % mItems.length].focus();
+        } else if (e.key === 'Escape') {
+          closeMenu();
+        }
+      });
+    });
+  });
+
+  const menuButton = nav.querySelector('#menu-button');
+  const mobilePanel = document.getElementById('mobile-panel');
+  const focusableSelectors = 'a[href], button:not([disabled])';
+  let mobileOpen = false;
+  function openMobile() {
+    mobilePanel.classList.remove('-translate-x-full');
+    menuButton.setAttribute('aria-expanded', 'true');
+    mobileOpen = true;
+    const first = mobilePanel.querySelector(focusableSelectors);
+    first && first.focus();
+  }
+  function closeMobile() {
+    mobilePanel.classList.add('-translate-x-full');
+    menuButton.setAttribute('aria-expanded', 'false');
+    mobileOpen = false;
+    menuButton.focus();
+  }
+  menuButton.addEventListener('click', () => {
+    mobileOpen ? closeMobile() : openMobile();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && mobileOpen) {
+      closeMobile();
+    }
+  });
+  mobilePanel.addEventListener('keydown', (e) => {
+    if (e.key !== 'Tab' || !mobileOpen) return;
+    const focusables = mobilePanel.querySelectorAll(focusableSelectors);
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
+  mobilePanel.querySelectorAll('.accordion-btn').forEach(btn => {
+    const panel = btn.nextElementSibling;
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
+      panel.classList.toggle('hidden');
+    });
+  });
+</script>

--- a/src/components/menuData.ts
+++ b/src/components/menuData.ts
@@ -1,0 +1,44 @@
+export const MENU = [
+  {
+    label: "Comienza",
+    columns: [
+      {
+        title: "Dominios",
+        items: [
+          { href: "/dominios/comprar", icon: "domain", label: "Comprar Dominio", desc: "Elige y registra tu dominio ideal." },
+          { href: "/dominios/transferir", icon: "transfer", label: "Transferir Dominio", desc: "Rápido y sin complicaciones." }
+        ]
+      },
+      {
+        title: "Hosting",
+        items: [
+          { href: "/hosting/wordpress", icon: "wp", label: "Hosting Wordpress", desc: "Rápido, seguro y actualizado." },
+          { href: "/hosting/web", icon: "server", label: "Hosting Web", desc: "Robusto para sitios dinámicos." }
+        ]
+      }
+    ]
+  },
+  {
+    label: "Crea",
+    columns: [
+      { title: "Desarrollo", items: [{ href: "/servicios/desarrollo", icon: "build", label: "Desarrollo Web", desc: "Webs que conectan y convierten." }] },
+      { title: "Creador", items: [{ href: "/herramientas/creador", icon: "cms", label: "Creador de webs", desc: "Creatividad visual sin límites." }] }
+    ]
+  },
+  {
+    label: "Crece",
+    columns: [
+      { title: "Marketing", items: [{ href: "/growth/360", icon: "target", label: "Growth 360", desc: "Estrategias para crecer." }, { href: "/growth/redes", icon: "chat", label: "Redes Sociales", desc: "Conecta con tu audiencia." }] },
+      { title: "Deportes", items: [{ href: "/growth/deportes", icon: "sport", label: "Marketing Deportivo", desc: "Especialización en deporte." }] }
+    ]
+  },
+  {
+    label: "Transforma",
+    columns: [
+      { title: "Cloud", items: [{ href: "/cloud/instancias", icon: "cloud", label: "Instancias Cloud", desc: "Escala sin límites." }] },
+      { title: "Servidores", items: [{ href: "/vps/linux", icon: "linux", label: "VPS Linux", desc: "Control y escalabilidad." }, { href: "/vps/windows", icon: "windows", label: "VPS Windows", desc: "Entorno Microsoft con admin." }] },
+      { title: "Administración", items: [{ href: "/admin/servidores", icon: "ops", label: "Administración de servidores", desc: "Gestión experta 24/7." }] },
+      { title: "Paneles", items: [{ href: "/paneles", icon: "panel", label: "Paneles de Control", desc: "cPanel, Plesk, CyberPanel." }] }
+    ]
+  }
+];

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,23 @@
+---
+export interface Props {
+  title: string;
+}
+const { title } = Astro.props as Props;
+import '../styles/global.css';
+---
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>{title}</title>
+  </head>
+  <body class="antialiased">
+    <header>
+      <slot name="nav" />
+    </header>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,12 @@
 ---
-import '../styles/global.css'
+import Layout from '../layouts/Base.astro';
+import NavMega from '../components/NavMega.astro';
+import { MENU } from '../components/menuData';
+const CTA = { href: '/area-cliente', label: 'Área del cliente' };
 ---
-
-<h1 class="text-6xl font-bold text-red-500 text-center mt-10">
-	Hola Avantys 🚀
-</h1>
+<Layout title="Avantys — Hosting y Servidores">
+  <Fragment slot="nav">
+    <NavMega menu={MENU} cta={CTA} />
+  </Fragment>
+  <h1 class="text-6xl font-bold text-red-500 text-center mt-10">Hola Avantys 🚀</h1>
+</Layout>


### PR DESCRIPTION
## Summary
- implement accessible megamenu with desktop hover panels and mobile drawer
- wire navbar into base layout and home page
- add temporary SEO blocking robots.txt

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b9f4856bd88321ac91048c4b9e72d6