### PR TITLE
feat: scaffold site structure

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import { fileURLToPath } from 'node:url';
 
 import tailwindcss from '@tailwindcss/vite';
 import tailwindConfig from './tailwind.config.js';
@@ -7,6 +8,11 @@ import tailwindConfig from './tailwind.config.js';
 // https://astro.build/config
 export default defineConfig({
   vite: {
-    plugins: [tailwindcss({ config: tailwindConfig })]
+    plugins: [tailwindcss({ config: tailwindConfig })],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url))
+      }
+    }
   }
 });

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -1,0 +1,10 @@
+---
+const year = new Date().getFullYear();
+---
+<footer class="py-4 text-center text-sm">
+  <p>© {year} Avantys</p>
+  <nav class="mt-2 flex justify-center gap-4">
+    <a href="/soporte">Soporte</a>
+    <a href="/contacto">Contacto</a>
+  </nav>
+</footer>

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -1,0 +1,13 @@
+---
+import Navigation from './Navigation.astro';
+const CTA = { href: '/area-cliente', label: 'Área del cliente' };
+---
+<header class="flex items-center justify-between py-4">
+  <a href="/" class="font-bold text-xl">Avantys</a>
+  <nav>
+    <slot name="nav">
+      <Navigation />
+    </slot>
+  </nav>
+  <a href={CTA.href} class="btn btn-primary">{CTA.label}</a>
+</header>

--- a/src/components/common/Layout.astro
+++ b/src/components/common/Layout.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+export interface Props {
+  title: string;
+  description?: string;
+  noindex?: boolean;
+}
+const props = Astro.props as Props;
+---
+<BaseLayout {...props}>
+  <Fragment slot="nav">
+    <slot name="nav" />
+  </Fragment>
+  <slot />
+</BaseLayout>

--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -1,0 +1,27 @@
+---
+let NavMega;
+try {
+  NavMega = (await import('../NavMega.astro')).default;
+} catch {}
+const links = [
+  { href: '/comienza', label: 'Comienza' },
+  { href: '/crece', label: 'Crece' },
+  { href: '/crea', label: 'Crea' },
+  { href: '/transforma', label: 'Transforma' },
+  { href: '/sobre-avantys', label: 'Sobre Avantys' },
+  { href: '/soporte', label: 'Soporte' },
+  { href: '/contacto', label: 'Contacto' }
+];
+let MENU;
+const CTA = { href: '/area-cliente', label: 'Área del cliente' };
+if (NavMega) {
+  MENU = (await import('../menuData')).MENU;
+}
+---
+{NavMega ? <NavMega menu={MENU} cta={CTA} /> : (
+  <nav class="flex gap-4">
+    {links.map((l) => (
+      <a href={l.href}>{l.label}</a>
+    ))}
+  </nav>
+)}

--- a/src/components/common/SEO.astro
+++ b/src/components/common/SEO.astro
@@ -1,0 +1,11 @@
+---
+export interface Props {
+  title: string;
+  description?: string;
+  noindex?: boolean;
+}
+const { title, description, noindex } = Astro.props as Props;
+---
+<title>{title}</title>
+{description && <meta name="description" content={description} />}
+{noindex && <meta name="robots" content="noindex, nofollow" />}

--- a/src/components/sections/CTA.astro
+++ b/src/components/sections/CTA.astro
@@ -1,0 +1,3 @@
+<section class="py-10">
+  <!-- TODO: implementar CTA -->
+</section>

--- a/src/components/sections/Features.astro
+++ b/src/components/sections/Features.astro
@@ -1,0 +1,3 @@
+<section class="py-10">
+  <!-- TODO: implementar Features -->
+</section>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -1,0 +1,3 @@
+<section class="py-10">
+  <!-- TODO: implementar Hero -->
+</section>

--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -1,0 +1,3 @@
+<section class="py-10">
+  <!-- TODO: implementar Services -->
+</section>

--- a/src/components/sections/Testimonials.astro
+++ b/src/components/sections/Testimonials.astro
@@ -1,0 +1,3 @@
+<section class="py-10">
+  <!-- TODO: implementar Testimonials -->
+</section>

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,0 +1,11 @@
+---
+interface Props {
+  href?: string;
+  variant?: string;
+}
+const { href = '#', variant } = Astro.props as Props;
+const classes = ['btn', variant === 'primary' ? 'btn-primary' : '']
+  .filter(Boolean)
+  .join(' ');
+---
+<a href={href} class={classes}><slot /></a>

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -1,0 +1,3 @@
+<div class="p-4 border rounded">
+  <!-- TODO: implementar -->
+</div>

--- a/src/components/ui/ContactForm.astro
+++ b/src/components/ui/ContactForm.astro
@@ -1,0 +1,3 @@
+<form class="p-4 border rounded">
+  <!-- TODO: implementar -->
+</form>

--- a/src/components/ui/PricingCard.astro
+++ b/src/components/ui/PricingCard.astro
@@ -1,0 +1,3 @@
+<div class="p-4 border rounded">
+  <!-- TODO: implementar -->
+</div>

--- a/src/components/ui/ServiceCard.astro
+++ b/src/components/ui/ServiceCard.astro
@@ -1,0 +1,3 @@
+<div class="p-4 border rounded">
+  <!-- TODO: implementar -->
+</div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,27 @@
+---
+import SEO from '../components/common/SEO.astro';
+import '../styles/global.css';
+
+export interface Props {
+  title: string;
+  description?: string;
+  noindex?: boolean;
+}
+
+const { title, description, noindex } = Astro.props as Props;
+---
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <SEO title={title} description={description} noindex={noindex} />
+  </head>
+  <body class="antialiased">
+    <header>
+      <slot name="nav" />
+    </header>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/pages/comienza/dominios.astro
+++ b/src/pages/comienza/dominios.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Dominios">
+  <Header slot="nav" />
+  <h1>Dominios</h1>
+  <Footer />
+</Layout>

--- a/src/pages/comienza/hosting.astro
+++ b/src/pages/comienza/hosting.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Hosting">
+  <Header slot="nav" />
+  <h1>Hosting</h1>
+  <Footer />
+</Layout>

--- a/src/pages/comienza/index.astro
+++ b/src/pages/comienza/index.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Comienza">
+  <Header slot="nav" />
+  <h1>Comienza</h1>
+  <Footer />
+</Layout>

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Contacto">
+  <Header slot="nav" />
+  <h1>Contacto</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crea/diseno-grafico.astro
+++ b/src/pages/crea/diseno-grafico.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Diseño Gráfico">
+  <Header slot="nav" />
+  <h1>Diseño Gráfico</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crea/diseno-web.astro
+++ b/src/pages/crea/diseno-web.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Diseño Web">
+  <Header slot="nav" />
+  <h1>Diseño Web</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crea/ecommerce.astro
+++ b/src/pages/crea/ecommerce.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Ecommerce">
+  <Header slot="nav" />
+  <h1>Ecommerce</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crea/index.astro
+++ b/src/pages/crea/index.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Crea">
+  <Header slot="nav" />
+  <h1>Crea</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crece/index.astro
+++ b/src/pages/crece/index.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Crece">
+  <Header slot="nav" />
+  <h1>Crece</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crece/marketing-digital.astro
+++ b/src/pages/crece/marketing-digital.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Marketing Digital">
+  <Header slot="nav" />
+  <h1>Marketing Digital</h1>
+  <Footer />
+</Layout>

--- a/src/pages/crece/publicidad-online.astro
+++ b/src/pages/crece/publicidad-online.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Publicidad Online">
+  <Header slot="nav" />
+  <h1>Publicidad Online</h1>
+  <Footer />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,15 @@
 ---
-import Layout from '../layouts/Base.astro';
-import NavMega from '../components/NavMega.astro';
-import { MENU } from '../components/menuData';
-const CTA = { href: '/area-cliente', label: 'Área del cliente' };
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+import Hero from '@/components/sections/Hero.astro';
+import Services from '@/components/sections/Services.astro';
+import CTA from '@/components/sections/CTA.astro';
 ---
 <Layout title="Avantys — Hosting y Servidores">
-  <Fragment slot="nav">
-    <NavMega menu={MENU} cta={CTA} />
-  </Fragment>
-  <h1 class="text-6xl font-bold text-red-500 text-center mt-10">Hola Avantys 🚀</h1>
+  <Header slot="nav" />
+  <Hero />
+  <Services />
+  <CTA />
+  <Footer />
 </Layout>

--- a/src/pages/sobre-avantys.astro
+++ b/src/pages/sobre-avantys.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Sobre Avantys">
+  <Header slot="nav" />
+  <h1>Sobre Avantys</h1>
+  <Footer />
+</Layout>

--- a/src/pages/soporte.astro
+++ b/src/pages/soporte.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Soporte">
+  <Header slot="nav" />
+  <h1>Soporte</h1>
+  <Footer />
+</Layout>

--- a/src/pages/transforma/administracion-servidores.astro
+++ b/src/pages/transforma/administracion-servidores.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Administración de Servidores">
+  <Header slot="nav" />
+  <h1>Administración de Servidores</h1>
+  <Footer />
+</Layout>

--- a/src/pages/transforma/index.astro
+++ b/src/pages/transforma/index.astro
@@ -1,0 +1,10 @@
+---
+import Layout from '@/components/common/Layout.astro';
+import Header from '@/components/common/Header.astro';
+import Footer from '@/components/common/Footer.astro';
+---
+<Layout title="Transforma">
+  <Header slot="nav" />
+  <h1>Transforma</h1>
+  <Footer />
+</Layout>

--- a/src/styles/museo-sans.css
+++ b/src/styles/museo-sans.css
@@ -1,0 +1,1 @@
+/* TODO: add Museo Sans font */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,16 @@
+import type { NavLink } from './types';
+
+export const SITE_CONFIG = {
+  name: 'Avantys',
+  lang: 'es'
+};
+
+export const NAV_LINKS: NavLink[] = [
+  { href: '/comienza', label: 'Comienza' },
+  { href: '/crece', label: 'Crece' },
+  { href: '/crea', label: 'Crea' },
+  { href: '/transforma', label: 'Transforma' },
+  { href: '/sobre-avantys', label: 'Sobre Avantys' },
+  { href: '/soporte', label: 'Soporte' },
+  { href: '/contacto', label: 'Contacto' }
+];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,10 @@
+export interface SEOProps {
+  title: string;
+  description?: string;
+  noindex?: boolean;
+}
+
+export interface NavLink {
+  href: string;
+  label: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
## Summary
- add base layout with SEO component and navigation slot
- scaffold common components and section stubs
- add placeholder pages and utility constants/types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ba001c90508321a630c265c0083f7e